### PR TITLE
[readme] replace lodash with native JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ You can easily do that:
 
 ```js
 import combinePromises from 'combine-promises';
-import { mapValues } from 'lodash';
 
 const friendsIds = { user1: 'userId-1', user2: 'userId-2' };
 
-const friends = await combinePromises(mapValues(friendsIds, fetchUserById));
+const friends = await combinePromises(
+  Object.fromEntries(Object.entries(friendsIds).map(([key, id]) => [key, fetchUserById(id)]))
+);
 ```
 
 Without this library: good luck to keep your code simple.


### PR DESCRIPTION
The use case is simple and can be easily written in native JS, so there is no real need to involve `lodash` in there. 

Also changing the example makes it more verbose - user do not need to know how `mapValues` works and what are the parameters passed in there. 

The rewritten example pseudo-code has been tested in there:
* https://codesandbox.io/s/jovial-goldstine-6uqto?file=/src/index.js