### PR TITLE
Allow non promise in input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "combine-promises",
   "author": "slorber",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-type UnwrapPromise<P extends unknown> = P extends PromiseLike<infer V>
-  ? V
-  : P;
+type UnwrapPromise<P extends unknown> = P extends PromiseLike<infer V> ? V : P;
 
 type Input = Record<string | number | symbol, unknown>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-type UnwrapPromise<P extends Promise<unknown>> = P extends PromiseLike<infer V>
+type UnwrapPromise<P extends unknown> = P extends PromiseLike<infer V>
   ? V
-  : never;
+  : P;
 
-type Input = Record<string | number | symbol, Promise<unknown>>;
+type Input = Record<string | number | symbol, unknown>;
 
 type Result<Obj extends Input> = {
   [P in keyof Obj]: UnwrapPromise<Obj[P]>;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -47,11 +47,9 @@ describe('combinePromises', () => {
     expect(result).toEqual({ user: createUser(1), company: createCompany(2) });
   });
 
-  it('can handle sync values, but TS errors', async () => {
-    // @ts-expect-error: "company" value should be async/Promise
+  it('can handle sync values', async () => {
     const result: { user: User; company: Company } = await combinePromises({
       user: fetchUser(1),
-      // @ts-expect-error: "company" value should be async/Promise
       company: createCompany(2),
     });
     expect(result).toEqual({ user: createUser(1), company: createCompany(2) });


### PR DESCRIPTION
In order to comply with Promise.all, the input should be able to accept non promise input and return it as is like Promise.all.